### PR TITLE
Fix race in TestStressShutdown

### DIFF
--- a/integration-tests/shutdown_test.go
+++ b/integration-tests/shutdown_test.go
@@ -224,7 +224,7 @@ func TestStressShutdown(t *testing.T) {
 					go func() {
 						defer wg.Done()
 						defer requestsWg.Done()
-						newCtx, cancelFn := context.WithTimeout(ctx, 5000*time.Millisecond)
+						newCtx, cancelFn := context.WithTimeout(goCtx, 5000*time.Millisecond)
 						tempCqlConn, err := client.NewTestClient(newCtx, "127.0.0.1:14002")
 						optionsWg := &sync.WaitGroup{}
 						if err == nil {


### PR DESCRIPTION
Fix race in TestStressShutdown by using the proper context to coordinate the goroutines that query the proxy.



┆Issue is synchronized with this [Jira Task](https://datastax.jira.com/browse/ZDM-467) by [Unito](https://www.unito.io)
┆friendlyId: ZDM-467
