### PR TITLE
#72 added aws_region parameter

### DIFF
--- a/fallout-tests/dse47-zdmproxy-benchmark-nb-vs-noproxy-astra-target.yaml
+++ b/fallout-tests/dse47-zdmproxy-benchmark-nb-vs-noproxy-astra-target.yaml
@@ -1,3 +1,4 @@
+aws_region: us-east-1
 origin_server_product: dse
 origin_server_install_type: tarball
 origin_server_version: 4.7.9
@@ -40,6 +41,7 @@ ensemble:
         name: ctool
         properties:
           cloud.provider: ec2
+          cloud.region: {{aws_region}}
           cloud.instance.type: {{instance_type}}
           cloud.instance.platform: {{origin_server_linux_distro}}
           mark_for_reuse: {{reuse}}
@@ -62,7 +64,7 @@ ensemble:
         name: astra
         properties:
           cloud.provider: aws
-          cloud.region: us-west-2
+          cloud.region: {{aws_region}}
           keyspace: benchmark2_ks
     - name: zdmproxy
       node.count: {{proxy_node_count}}
@@ -70,6 +72,7 @@ ensemble:
         name: ctool
         properties:
           cloud.provider: ec2
+          cloud.region: {{aws_region}}
           cloud.instance.type: {{instance_type}}
           mark_for_reuse: {{reuse}}
           cluster_ttl: {{ttl}}
@@ -79,6 +82,7 @@ ensemble:
       name: ctool
       properties:
         cloud.provider: ec2
+        cloud.region: {{aws_region}}
         cloud.instance.type: {{instance_type}}
         mark_for_reuse: {{reuse}}
         cluster_ttl: {{ttl}}

--- a/fallout-tests/external-cqlsh-zdmproxy-benchmark-nb-vs-noproxy-astra-target.yaml
+++ b/fallout-tests/external-cqlsh-zdmproxy-benchmark-nb-vs-noproxy-astra-target.yaml
@@ -1,3 +1,4 @@
+aws_region: us-east-1
 origin_server_product: cassandra
 origin_server_install_type: tarball
 origin_server_version: 2.1.6
@@ -39,6 +40,7 @@ ensemble:
         name: ctool
         properties:
           cloud.provider: ec2
+          cloud.region: {{aws_region}}
           cloud.instance.type: {{instance_type}}
           cloud.instance.platform: {{origin_server_linux_distro}}
           mark_for_reuse: {{reuse}}
@@ -60,7 +62,7 @@ ensemble:
         name: astra
         properties:
           cloud.provider: aws
-          cloud.region: us-west-2
+          cloud.region: {{aws_region}}
           keyspace: benchmark2_ks
     - name: zdmproxy
       node.count: {{proxy_node_count}}
@@ -68,6 +70,7 @@ ensemble:
         name: ctool
         properties:
           cloud.provider: ec2
+          cloud.region: {{aws_region}}
           cloud.instance.type: {{instance_type}}
           mark_for_reuse: {{reuse}}
           cluster_ttl: {{ttl}}
@@ -77,6 +80,7 @@ ensemble:
       name: ctool
       properties:
         cloud.provider: ec2
+        cloud.region: {{aws_region}}
         cloud.instance.type: {{instance_type}}
         mark_for_reuse: {{reuse}}
         cluster_ttl: {{ttl}}

--- a/fallout-tests/zdmproxy-benchmark-nb-vs-noproxy-astra-target.yaml
+++ b/fallout-tests/zdmproxy-benchmark-nb-vs-noproxy-astra-target.yaml
@@ -1,3 +1,4 @@
+aws_region: us-east-1
 origin_server_product: dse
 origin_server_install_type: tarball
 origin_server_version: 5.1.33
@@ -40,6 +41,7 @@ ensemble:
         properties:
           cloud.provider: ec2
           cloud.instance.type: {{instance_type}}
+          cloud.region: {{aws_region}}
           cloud.instance.platform: {{origin_server_linux_distro}}
           mark_for_reuse: {{reuse}}
           cluster_ttl: {{ttl}}
@@ -60,7 +62,7 @@ ensemble:
         name: astra
         properties:
           cloud.provider: aws
-          cloud.region: us-west-2
+          cloud.region: {{aws_region}}
           keyspace: benchmark2_ks
     - name: zdmproxy
       node.count: {{proxy_node_count}}
@@ -68,6 +70,7 @@ ensemble:
         name: ctool
         properties:
           cloud.provider: ec2
+          cloud.region: {{aws_region}}
           cloud.instance.type: {{instance_type}}
           mark_for_reuse: {{reuse}}
           cluster_ttl: {{ttl}}
@@ -77,6 +80,7 @@ ensemble:
       name: ctool
       properties:
         cloud.provider: ec2
+        cloud.region: {{aws_region}}
         cloud.instance.type: {{instance_type}}
         mark_for_reuse: {{reuse}}
         cluster_ttl: {{ttl}}
@@ -85,6 +89,7 @@ ensemble:
         properties:
           java.version: openjdk8
       - name: nosqlbench_ssh
+      - name: cqlsh
   observer: none
 workload:
   phases:

--- a/fallout-tests/zdmproxy-benchmark-nb-vs-noproxy.yaml
+++ b/fallout-tests/zdmproxy-benchmark-nb-vs-noproxy.yaml
@@ -102,6 +102,7 @@ ensemble:
         properties:
           java.version: openjdk8
       - name: nosqlbench_ssh
+      - name: cqlsh
   observer: none
 workload:
   phases:

--- a/fallout-tests/zdmproxy-benchmark-nb.yaml
+++ b/fallout-tests/zdmproxy-benchmark-nb.yaml
@@ -102,6 +102,7 @@ ensemble:
         properties:
           java.version: openjdk8
       - name: nosqlbench_ssh
+      - name: cqlsh
   observer: none
 workload:
   phases:


### PR DESCRIPTION
so that we can provision in us-east-1 and avoid the unsupported region error with Astra dev env



┆Issue is synchronized with this [Jira Task](https://datastax.jira.com/browse/ZDM-477) by [Unito](https://www.unito.io)
┆friendlyId: ZDM-477
