### PR TITLE
ZDM-517 remove shell access from the docker image #95

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN cp /build/main .
 # Build a small image
 FROM alpine
 
+# remove shell access
+RUN rm /bin/ash /bin/sh /usr/bin/nsenter
+
 COPY --from=builder /dist/main /
 COPY LICENSE /
 


### PR DESCRIPTION
@alicel could you please help to review this change? As it is a docker image change, which is not covered by our automated tests, so I've done some manual test in my cloud cluster to ensure it doesn't affect existing functionalities. When I try to gain shell access I'm now greeted with the following error:

```
[ubuntu@ip-172-18-10-90 ~]$ docker exec -it zdm-proxy-container sh
OCI runtime exec failed: exec failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown
[ubuntu@ip-172-18-10-90 ~]$ docker exec -it zdm-proxy-container ash
OCI runtime exec failed: exec failed: unable to start container process: exec: "ash": executable file not found in $PATH: unknown
[ubuntu@ip-172-18-10-90 ~]$ docker exec -it zdm-proxy-container bash
OCI runtime exec failed: exec failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown
[ubuntu@ip-172-18-10-90 ~]$ docker exec -it zdm-proxy-container nsenter
OCI runtime exec failed: exec failed: unable to start container process: exec: "nsenter": executable file not found in $PATH: unknown
[ubuntu@ip-172-18-10-90 ~]$ docker exec -it zdm-proxy-container /bin/sh
OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/sh": stat /bin/sh: no such file or directory: unknown
[ubuntu@ip-172-18-10-90 ~]$ docker exec -it zdm-proxy-container /bin/ash
OCI runtime exec failed: exec failed: unable to start container process: exec: "/bin/ash": stat /bin/ash: no such file or directory: unknown
```