### PR TITLE
Add config for controlling node ip resolution ordering

### DIFF
--- a/proxy/pkg/config/config.go
+++ b/proxy/pkg/config/config.go
@@ -47,6 +47,8 @@ type Config struct {
 	OriginTlsClientCertPath string `split_words:"true" yaml:"origin_tls_client_cert_path"`
 	OriginTlsClientKeyPath  string `split_words:"true" yaml:"origin_tls_client_key_path"`
 
+	OriginPreferIpFromSystemLocal bool `default:"true" split_words:"true" yaml:"origin_prefer_ip_from_system_local"`
+
 	// Target bucket
 
 	TargetContactPoints           string `split_words:"true" yaml:"target_contact_points"`
@@ -60,6 +62,8 @@ type Config struct {
 	TargetTlsServerCaPath   string `split_words:"true" yaml:"target_tls_server_ca_path"`
 	TargetTlsClientCertPath string `split_words:"true" yaml:"target_tls_client_cert_path"`
 	TargetTlsClientKeyPath  string `split_words:"true" yaml:"target_tls_client_key_path"`
+
+	TargetPreferIpFromSystemLocal bool `default:"true" split_words:"true" yaml:"target_prefer_ip_from_system_local"`
 
 	// Proxy bucket
 

--- a/proxy/pkg/zdmproxy/controlconn.go
+++ b/proxy/pkg/zdmproxy/controlconn.go
@@ -481,13 +481,13 @@ func (cc *ControlConn) RefreshHosts(conn CqlConnection, ctx context.Context) ([]
 	peersListLocalHost, peersListContainsLocalHost := hostsById[localHost.HostId]
 	if cc.preferIpFromSystemLocal {
 		if peersListContainsLocalHost {
-			log.Warnf("Local host is also on the peers list: %v vs %v, ignoring the former one.", peersListLocalHost, localHost)
+			log.Warnf("Local host is also on the peers list, local host will be used as the source of truth: %v vs %v, ignoring the former one.", peersListLocalHost, localHost)
 		}
 		hostsById[localHost.HostId] = localHost
 	} else if peersListContainsLocalHost {
-		log.Infof("Local host is on the peers list aswell, the peers list will be used as the source of truth: %v vs %v, ignoring the latter one.", peersListLocalHost, localHost)
+		log.Warnf("Local host is also on the peers list, the peers list will be used as the source of truth: %v vs %v, ignoring the latter one.", peersListLocalHost, localHost)
 	} else {
-		log.Warnf("Local host is not on the peers list, it will be added: %v.", localHost)
+		log.Tracef("Local host is not on the peers list, it will be added: %v.", localHost)
 		hostsById[localHost.HostId] = localHost
 	}
 

--- a/proxy/pkg/zdmproxy/proxy.go
+++ b/proxy/pkg/zdmproxy/proxy.go
@@ -249,7 +249,7 @@ func (p *ZdmProxy) initializeControlConnections(ctx context.Context) error {
 
 	originControlConn := NewControlConn(
 		p.controlConnShutdownCtx, p.Conf.OriginPort, p.originConnectionConfig,
-		p.Conf.OriginUsername, p.Conf.OriginPassword, p.Conf, topologyConfig, p.proxyRand, p.metricHandler)
+		p.Conf.OriginUsername, p.Conf.OriginPassword, p.Conf, topologyConfig, p.proxyRand, p.metricHandler, p.Conf.OriginPreferIpFromSystemLocal)
 
 	if err := originControlConn.Start(p.controlConnShutdownWg, ctx); err != nil {
 		return fmt.Errorf("failed to initialize origin control connection: %w", err)
@@ -261,7 +261,7 @@ func (p *ZdmProxy) initializeControlConnections(ctx context.Context) error {
 
 	targetControlConn := NewControlConn(
 		p.controlConnShutdownCtx, p.Conf.TargetPort, p.targetConnectionConfig,
-		p.Conf.TargetUsername, p.Conf.TargetPassword, p.Conf, topologyConfig, p.proxyRand, p.metricHandler)
+		p.Conf.TargetUsername, p.Conf.TargetPassword, p.Conf, topologyConfig, p.proxyRand, p.metricHandler, p.Conf.TargetPreferIpFromSystemLocal)
 
 	if err := targetControlConn.Start(p.controlConnShutdownWg, ctx); err != nil {
 		return fmt.Errorf("failed to initialize target control connection: %w", err)


### PR DESCRIPTION
Hello,

During node discovery, when ZDM proxy finds an entry present in both `system.peers` and `system.local` it currently will always prefer node IP addresses returned by `system.local`. Some Cassandra implementations handle `system.local` & `system.peer` tables differently, when the `system.peer` table contains ALL nodes in the cluster and the ip addresses from `system.local` are invalid or should not be used then zdm-proxy will currently not work.

This PR adds 2 new config properties (both defaulting to true, to maintain backwards compatability):
- `OriginPreferIpFromSystemLocal` - Sets origin clusters to prefer IP address from `system.local`
- `TargetPreferIpFromSystemLocal` - Sets target clusters to prefer IP address from `system.local`

These can be used to control the resolution order of IP addresses and would allow for DataStax customers to better migrate from other Cassandra providers.

I am putting this PR out in its current form as an initial conversation starter, I am more than happy to add test coverage for this change, or make other changes, if it is a feature DataStax approves of.