### PR TITLE
Handle nil control connection when reconnecting

### DIFF
--- a/proxy/pkg/zdmproxy/clienthandler.go
+++ b/proxy/pkg/zdmproxy/clienthandler.go
@@ -159,6 +159,15 @@ func NewClientHandler(
 		}
 	}
 
+	originCCProtoVer, err := originControlConn.LoadProtoVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load protocol version from %v: %w", common.ClusterTypeOrigin, err)
+	}
+	targetCCProtoVer, err := targetControlConn.LoadProtoVersion()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load protocol version from %v: %w", common.ClusterTypeTarget, err)
+	}
+
 	nodeMetrics, err := metricHandler.GetNodeMetrics(originEndpointId, targetEndpointId, asyncEndpointId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create node metrics: %w", err)
@@ -169,8 +178,6 @@ func NewClientHandler(
 	requestsDoneCtx, requestsDoneCancelFn := context.WithCancel(context.Background())
 
 	// Initialize stream id processors to manage the ids sent to the clusters
-	originCCProtoVer := originControlConn.cqlConn.GetProtocolVersion()
-	targetCCProtoVer := targetControlConn.cqlConn.GetProtocolVersion()
 	// Calculate maximum number of stream IDs. Take the oldest protocol version negotiated between two clusters
 	// and apply limit defined in proxy configuration. If origin or target cluster are still running protocol V2,
 	// we will limit maximum number of stream IDs to 127 on both clusters. Logic is based on Java driver version 3.x.


### PR DESCRIPTION
`ControlConn.cqlConn` can equal `nil` when old connection becomes invalid and `ControlConn.Close()` has been executed., but new control connection has not been yet established by reconnection routine. Code should handle the situation when `ControlConn.cqlConn` is `nil`, otherwise we fail with:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x101280f54]

goroutine 247 [running]:
github.com/datastax/zdm-proxy/proxy/pkg/zdmproxy.NewClientHandler({0x101645f98, 0x1400042c0c0}, 0x140001c5e60, 0x140001c5e38, 0x1400021bce0, 0x14000476000, 0x140000f4008, 0x140002d2c80, {0x101386b16, 0x9}, ...)
	~/zdm-proxy/proxy/pkg/zdmproxy/clienthandler.go:172 +0x214
github.com/datastax/zdm-proxy/proxy/pkg/zdmproxy.(*ZdmProxy).handleNewConnection(0x140002c6380, {0x101645f98, 0x1400042c0c0})
	~/zdm-proxy/proxy/pkg/zdmproxy/proxy.go:545 +0x510
github.com/datastax/zdm-proxy/proxy/pkg/zdmproxy.(*ZdmProxy).acceptConnectionsFromClients.func1.2()
	~/zdm-proxy/proxy/pkg/zdmproxy/proxy.go:487 +0x54
github.com/datastax/zdm-proxy/proxy/pkg/zdmproxy.NewScheduler.func1()
	~/zdm-proxy/proxy/pkg/zdmproxy/scheduler.go:25 +0x5c
created by github.com/datastax/zdm-proxy/proxy/pkg/zdmproxy.NewScheduler in goroutine 20
	~/zdm-proxy/proxy/pkg/zdmproxy/scheduler.go:18 +0xac
```