### PR TITLE
Support CQL request compression

### DIFF
--- a/CHANGELOG/CHANGELOG-2.3.md
+++ b/CHANGELOG/CHANGELOG-2.3.md
@@ -7,6 +7,7 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 ## Unreleased
 
 * [#150](https://github.com/datastax/zdm-proxy/issues/150): CQL request tracing
+* [#154](https://github.com/datastax/zdm-proxy/issues/154): Support CQL request compression
 
 ---
 

--- a/integration-tests/basicupdate_test.go
+++ b/integration-tests/basicupdate_test.go
@@ -5,6 +5,8 @@ import (
 	"github.com/datastax/zdm-proxy/integration-tests/env"
 	"github.com/datastax/zdm-proxy/integration-tests/setup"
 	"github.com/datastax/zdm-proxy/integration-tests/utils"
+	"github.com/gocql/gocql"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -37,6 +39,57 @@ func TestBasicUpdate(t *testing.T) {
 
 	// Connect to proxy as a "client"
 	proxy, err := utils.ConnectToCluster("127.0.0.1", "", "", 14002)
+
+	if err != nil {
+		t.Log("Unable to connect to proxy session.")
+		t.Fatal(err)
+	}
+	defer proxy.Close()
+
+	// Run query on proxied connection
+	err = proxy.Query(fmt.Sprintf("UPDATE %s.%s SET task = 'terrance' WHERE id = d1b05da0-8c20-11ea-9fc6-6d2c86545d91;", setup.TestKeyspace, setup.TasksModel)).Exec()
+	if err != nil {
+		t.Log("Mid-migration update failed.")
+		t.Fatal(err)
+	}
+
+	// Assertions!
+	itr := targetCluster.GetSession().Query(fmt.Sprintf("SELECT * FROM %s.%s WHERE id = d1b05da0-8c20-11ea-9fc6-6d2c86545d91;", setup.TestKeyspace, setup.TasksModel)).Iter()
+	row := make(map[string]interface{})
+
+	require.True(t, itr.MapScan(row))
+	task := setup.MapToTask(row)
+
+	setup.AssertEqual(t, "terrance", task.Task)
+}
+
+func TestCompression(t *testing.T) {
+	if !env.RunCcmTests {
+		t.Skip("Test requires CCM, set RUN_CCMTESTS env variable to TRUE")
+	}
+
+	log.SetLevel(log.TraceLevel)
+	defer log.SetLevel(log.InfoLevel)
+
+	proxyInstance, err := NewProxyInstanceForGlobalCcmClusters()
+	require.Nil(t, err)
+	defer proxyInstance.Shutdown()
+
+	originCluster, targetCluster, err := SetupOrGetGlobalCcmClusters()
+	require.Nil(t, err)
+
+	// Initialize test data
+	data := [][]string{
+		{"cf0f4cf0-8c20-11ea-9fc6-6d2c86545d91", "MSzZMTWA9hw6tkYWPTxT0XfGL9nGQUpy"},
+	}
+
+	// Seed originCluster and targetCluster w/ schema and data
+	setup.SeedData(originCluster.GetSession(), targetCluster.GetSession(), setup.TasksModel, data)
+
+	// Connect to proxy as a "client"
+	cluster := utils.NewCluster("127.0.0.1", "", "", 14002)
+	cluster.Compressor = gocql.SnappyCompressor{}
+	proxy, err := cluster.CreateSession()
 
 	if err != nil {
 		t.Log("Unable to connect to proxy session.")

--- a/integration-tests/options_test.go
+++ b/integration-tests/options_test.go
@@ -16,8 +16,8 @@ func TestOptionsShouldComeFromTarget(t *testing.T) {
 	testSetup, err := setup.NewCqlServerTestSetup(t, conf, false, false, false)
 	require.Nil(t, err)
 	defer testSetup.Cleanup()
-	testSetup.Origin.CqlServer.RequestHandlers = []client.RequestHandler{client.RegisterHandler, newOptionsHandler("origin"), client.HandshakeHandler, client.NewSystemTablesHandler("cluster2", "dc2")}
-	testSetup.Target.CqlServer.RequestHandlers = []client.RequestHandler{client.RegisterHandler, newOptionsHandler("target"), client.HandshakeHandler, client.NewSystemTablesHandler("cluster1", "dc1")}
+	testSetup.Origin.CqlServer.RequestHandlers = []client.RequestHandler{client.RegisterHandler, newOptionsHandler(map[string][]string{"FROM": {"origin"}}), client.HandshakeHandler, client.NewSystemTablesHandler("cluster2", "dc2")}
+	testSetup.Target.CqlServer.RequestHandlers = []client.RequestHandler{client.RegisterHandler, newOptionsHandler(map[string][]string{"FROM": {"target"}}), client.HandshakeHandler, client.NewSystemTablesHandler("cluster1", "dc1")}
 
 	err = testSetup.Start(conf, true, primitive.ProtocolVersion4)
 	require.Nil(t, err)
@@ -31,7 +31,28 @@ func TestOptionsShouldComeFromTarget(t *testing.T) {
 
 }
 
-func newOptionsHandler(from string) client.RequestHandler {
+func TestCommonCompressionAlgorithms(t *testing.T) {
+
+	conf := setup.NewTestConfig("127.0.1.1", "127.0.1.2")
+	testSetup, err := setup.NewCqlServerTestSetup(t, conf, false, false, false)
+	require.Nil(t, err)
+	defer testSetup.Cleanup()
+	testSetup.Origin.CqlServer.RequestHandlers = []client.RequestHandler{client.RegisterHandler, newOptionsHandler(map[string][]string{"COMPRESSION": {"snappy"}}), client.HandshakeHandler, client.NewSystemTablesHandler("cluster2", "dc2")}
+	testSetup.Target.CqlServer.RequestHandlers = []client.RequestHandler{client.RegisterHandler, newOptionsHandler(map[string][]string{"COMPRESSION": {"snappy", "lz4"}}), client.HandshakeHandler, client.NewSystemTablesHandler("cluster1", "dc1")}
+
+	err = testSetup.Start(conf, true, primitive.ProtocolVersion4)
+	require.Nil(t, err)
+
+	request := frame.NewFrame(primitive.ProtocolVersion4, client.ManagedStreamId, &message.Options{})
+	response, err := testSetup.Client.CqlConnection.SendAndReceive(request)
+	require.Nil(t, err)
+	require.IsType(t, &message.Supported{}, response.Body.Message)
+	supported := response.Body.Message.(*message.Supported)
+	require.Equal(t, []string{"snappy"}, supported.Options["COMPRESSION"])
+
+}
+
+func newOptionsHandler(options map[string][]string) client.RequestHandler {
 	return func(
 		request *frame.Frame,
 		conn *client.CqlServerConnection,
@@ -41,7 +62,7 @@ func newOptionsHandler(from string) client.RequestHandler {
 			response = frame.NewFrame(
 				request.Header.Version,
 				request.Header.StreamId,
-				&message.Supported{Options: map[string][]string{"FROM": {from}}},
+				&message.Supported{Options: options},
 			)
 		}
 		return

--- a/integration-tests/stress_test.go
+++ b/integration-tests/stress_test.go
@@ -110,7 +110,6 @@ func TestSimultaneousConnections(t *testing.T) {
 						}
 						time.Sleep(200 * time.Millisecond)
 					}
-
 				}()
 			}
 		}()

--- a/proxy/pkg/zdmproxy/controlconn.go
+++ b/proxy/pkg/zdmproxy/controlconn.go
@@ -56,6 +56,7 @@ type ControlConn struct {
 	authEnabled              *atomic.Value
 	metricsHandler           *metrics.MetricHandler
 	controlConnProtoVersion  *atomic.Value
+	supportedResponse        *atomic.Value
 }
 
 const ProxyVirtualRack = "rack0"
@@ -104,6 +105,7 @@ func NewControlConn(ctx context.Context, defaultPort int, connConfig ConnectionC
 		authEnabled:              authEnabled,
 		metricsHandler:           metricsHandler,
 		controlConnProtoVersion:  &atomic.Value{},
+		supportedResponse:        &atomic.Value{},
 	}
 }
 
@@ -737,6 +739,14 @@ func (cc *ControlConn) LoadProtoVersion() (primitive.ProtocolVersion, error) {
 	}
 
 	panic("invalid type for protocol version")
+}
+
+func (cc *ControlConn) SetSupportedResponse(supported *message.Supported) {
+	cc.supportedResponse.Store(supported)
+}
+
+func (cc *ControlConn) GetSupportedResponse() *message.Supported {
+	return cc.supportedResponse.Load().(*message.Supported)
 }
 
 func computeAssignedHosts(index int, count int, orderedHosts []*Host) []*Host {

--- a/proxy/pkg/zdmproxy/cqlparser_adv_workloads_utils_test.go
+++ b/proxy/pkg/zdmproxy/cqlparser_adv_workloads_utils_test.go
@@ -74,7 +74,7 @@ func convertEncodedRequestToRawFrameForTests(queryFrame *frame.Frame, t *testing
 func parseEncodedRequestForTests(queryRawFrame *frame.RawFrame, t *testing.T) (RequestInfo, error) {
 	generalParams := getGeneralParamsForTests(t)
 
-	return buildRequestInfo(&frameDecodeContext{frame: queryRawFrame},
+	return buildRequestInfo(&frameDecodeContext{frame: queryRawFrame, compression: primitive.CompressionNone},
 		[]*statementReplacedTerms{},
 		generalParams.psCache,
 		generalParams.mh,

--- a/proxy/pkg/zdmproxy/cqlparser_test.go
+++ b/proxy/pkg/zdmproxy/cqlparser_test.go
@@ -138,7 +138,7 @@ func TestInspectFrame(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			timeUuidGenerator, err := GetDefaultTimeUuidGenerator()
 			require.Nil(t, err)
-			actual, err := buildRequestInfo(&frameDecodeContext{frame: tt.args.f}, []*statementReplacedTerms{{
+			actual, err := buildRequestInfo(&frameDecodeContext{frame: tt.args.f, compression: primitive.CompressionNone}, []*statementReplacedTerms{{
 				statementIndex: 0,
 				replacedTerms:  tt.args.replacedTerms,
 			}}, psCache, mh, km, tt.args.primaryCluster, tt.args.forwardSystemQueriesToTarget, true, tt.args.forwardAuthToTarget, timeUuidGenerator)

--- a/proxy/pkg/zdmproxy/frame.go
+++ b/proxy/pkg/zdmproxy/frame.go
@@ -3,7 +3,10 @@ package zdmproxy
 import (
 	"context"
 	"fmt"
+	"github.com/datastax/go-cassandra-native-protocol/compression/lz4"
+	"github.com/datastax/go-cassandra-native-protocol/compression/snappy"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"io"
 )
 
@@ -16,6 +19,15 @@ func (e *shutdownError) Error() string {
 }
 
 var defaultCodec = frame.NewRawCodec()
+
+var codecs = map[primitive.Compression]frame.RawCodec{
+	primitive.CompressionNone:       defaultCodec,
+	primitive.CompressionLz4:        frame.NewRawCodecWithCompression(lz4.Compressor{}),
+	primitive.CompressionSnappy:     frame.NewRawCodecWithCompression(snappy.Compressor{}),
+	primitive.Compression("none"):   defaultCodec,
+	primitive.Compression("lz4"):    frame.NewRawCodecWithCompression(lz4.Compressor{}),
+	primitive.Compression("snappy"): frame.NewRawCodecWithCompression(snappy.Compressor{}),
+}
 
 var ShutdownErr = &shutdownError{err: "aborted due to shutdown request"}
 
@@ -33,13 +45,13 @@ func adaptConnErr(connectionAddr string, clientHandlerContext context.Context, e
 
 // Simple function that writes a rawframe with a single call to writeToConnection
 func writeRawFrame(writer io.Writer, connectionAddr string, clientHandlerContext context.Context, frame *frame.RawFrame) error {
-	err := defaultCodec.EncodeRawFrame(frame, writer)
+	err := defaultCodec.EncodeRawFrame(frame, writer) // body is already compressed if needed, so we can use default codec
 	return adaptConnErr(connectionAddr, clientHandlerContext, err)
 }
 
 // Simple function that reads data from a connection and builds a frame
 func readRawFrame(reader io.Reader, connectionAddr string, clientHandlerContext context.Context) (*frame.RawFrame, error) {
-	rawFrame, err := defaultCodec.DecodeRawFrame(reader)
+	rawFrame, err := defaultCodec.DecodeRawFrame(reader) // body is not being decompressed, so we can use default codec
 	if err != nil {
 		return nil, adaptConnErr(connectionAddr, clientHandlerContext, err)
 	}

--- a/proxy/pkg/zdmproxy/querymodifier_test.go
+++ b/proxy/pkg/zdmproxy/querymodifier_test.go
@@ -154,7 +154,7 @@ func TestReplaceQueryString(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			context := &frameDecodeContext{frame: test.f}
+			context := &frameDecodeContext{frame: test.f, compression: primitive.CompressionNone}
 			timeUuidGenerator, err := GetDefaultTimeUuidGenerator()
 			require.Nil(t, err)
 			statementsQueryData, err := context.GetOrInspectAllStatements("", timeUuidGenerator)
@@ -166,7 +166,7 @@ func TestReplaceQueryString(t *testing.T) {
 			require.Nil(t, err)
 			_, decodedFrame, statementQuery, statementsReplacedTerms, err := queryModifier.replaceQueryString(decodedFrame, statementQuery)
 			newRawFrame, err := defaultCodec.ConvertToRawFrame(decodedFrame)
-			newContext := NewInitializedFrameDecodeContext(newRawFrame, decodedFrame, statementQuery)
+			newContext := NewInitializedFrameDecodeContext(newRawFrame, primitive.CompressionNone, decodedFrame, statementQuery)
 			require.Nil(t, err)
 			require.Equal(t, len(test.positionsReplaced), len(statementsReplacedTerms))
 			require.Equal(t, len(test.replacedTerms), len(statementsReplacedTerms))


### PR DESCRIPTION
Implement support for CQL request compression. Compression algorithm is chosen by the client application and passed to ZDM as part of `STARTUP` message. ZDM assumes that same algorithm is available at origin and target. We do not decompress and recompress CQL requests using algorithms supported by downstream clusters.

Fixes https://github.com/datastax/zdm-proxy/issues/154.