### PR TITLE
Fix decompression buffer size for LZ4

### DIFF
--- a/CHANGELOG/CHANGELOG-2.4.md
+++ b/CHANGELOG/CHANGELOG-2.4.md
@@ -6,6 +6,14 @@ When cutting a new release, update the `unreleased` heading to the tag being gen
 
 ---
 
+## v2.4.1 - 2026-01-30
+
+### Bug Fixes
+
+* [#154](https://github.com/datastax/zdm-proxy/issues/154): Fix too small buffer for LZ4 decompression
+
+---
+
 ## v2.4.0 - 2026-01-16
 
 ### New Features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,12 @@ Build artifacts are available at [Docker Hub](https://hub.docker.com/repository/
 
 For additional details on the changes included in a specific release, see the associated CHANGELOG-x.x.md file.
 
+## v2.4.1 - 2026-01-30
+
+Fix too small buffer for LZ4 decompression.
+
+[Changelog](CHANGELOG/CHANGELOG-2.4.md#v241---2026-01-30)
+
 ## v2.4.0 - 2026-01-16
 
 Support LZ4 and snappy compression.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/apache/cassandra-gocql-driver/v2 v2.0.0
-	github.com/datastax/go-cassandra-native-protocol v0.0.0-20240903140133-605a850e203b
+	github.com/datastax/go-cassandra-native-protocol v0.0.0-20260130100129-9d5b43677a33
 	github.com/google/uuid v1.1.1
 	github.com/jpillora/backoff v1.0.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/datastax/go-cassandra-native-protocol v0.0.0-20240903140133-605a850e203b h1:o7DLYw053jrHE9ii7pO4t/5GT6d/s6Eko+Szzj4j894=
-github.com/datastax/go-cassandra-native-protocol v0.0.0-20240903140133-605a850e203b/go.mod h1:6FzirJfdffakAVqmHjwVfFkpru/gNbIazUOK5rIhndc=
+github.com/datastax/go-cassandra-native-protocol v0.0.0-20260130100129-9d5b43677a33 h1:uZm/O9/kWeVFcSjoViRxl+JGsb0iF2Qes7lahyf9/X8=
+github.com/datastax/go-cassandra-native-protocol v0.0.0-20260130100129-9d5b43677a33/go.mod h1:6FzirJfdffakAVqmHjwVfFkpru/gNbIazUOK5rIhndc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/proxy/launch.go
+++ b/proxy/launch.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TODO: to be managed externally
-const ZdmVersionString = "2.4.0"
+const ZdmVersionString = "2.4.1"
 
 var displayVersion = flag.Bool("version", false, "display the ZDM proxy version and exit")
 var configFile = flag.String("config", "", "specify path to ZDM configuration file")


### PR DESCRIPTION
Upgrade `go-cassandra-native-protocol` library to after fixing https://github.com/datastax/go-cassandra-native-protocol/pull/61.